### PR TITLE
Removed dist from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
per canvas instructions : "Make sure that you remove dist from the .gitignore file so that Git will track this folder and include it when you push up to your application's repository."